### PR TITLE
Refactor - no more web app

### DIFF
--- a/.template.env
+++ b/.template.env
@@ -2,10 +2,14 @@
 STAGE=
 
 # API Gateway Base URL
-API_URL=https://**********.execute-api.us-east-2.amazonaws.com/${STAGE}
+# API URL is API_BASE_URL/STAGE
+API_BASE_URL=https://**********.execute-api.us-east-2.amazonaws.com/
 
 # DynamoDB Table Name
 TABLE_NAME=global_watchlist_${STAGE}
 
 # S3 Bucket for Match Uploads
 S3_BUCKET=match-uploads-${STAGE}
+
+# API Key for API Gateway
+API_KEY=**********

--- a/lambda/watchlist-management/index.js
+++ b/lambda/watchlist-management/index.js
@@ -4,6 +4,7 @@ const {
   ScanCommand,
   PutCommand,
   GetCommand,
+  DeleteCommand,
 } = require("@aws-sdk/lib-dynamodb");
 
 const client = new DynamoDBClient({});

--- a/lambda/watchlist-management/index.js
+++ b/lambda/watchlist-management/index.js
@@ -93,6 +93,7 @@ exports.handler = async (event) => {
       const putAuditParams = {
         TableName: AUDIT_LOG_TABLE,
         Item: {
+          log_id: `log-${Date.now()}`,
           plate_number,
           reason,
           added_by,

--- a/lambda/watchlist-management/index.js
+++ b/lambda/watchlist-management/index.js
@@ -107,6 +107,42 @@ exports.handler = async (event) => {
       };
     }
 
+    // ================== DELETE /plates/{plate_number} ==================
+    if (httpMethod === "DELETE") {
+      if (!event.pathParameters || !event.pathParameters.plate_number) {
+        return {
+          statusCode: 400,
+          body: JSON.stringify({ error: "plate_number is required" }),
+        };
+      }
+
+      const plate_number = event.pathParameters.plate_number;
+
+      // Check if plate exists
+      const getParams = { TableName: WATCHLIST_TABLE, Key: { plate_number } };
+      const existingPlate = await dynamoDB.send(new GetCommand(getParams));
+
+      if (!existingPlate.Item) {
+        return {
+          statusCode: 404,
+          body: JSON.stringify({ error: "Plate not found in watchlist" }),
+        };
+      }
+
+      // Remove plate from watchlist
+      await dynamoDB.send(
+        new DeleteCommand({
+          TableName: WATCHLIST_TABLE,
+          Key: { plate_number },
+        })
+      );
+
+      return {
+        statusCode: 200,
+        body: JSON.stringify({ message: "Plate removed from watchlist" }),
+      };
+    }
+
     return {
       statusCode: 400,
       body: JSON.stringify({ error: "Invalid request" }),

--- a/lambda/watchlist-management/index.js
+++ b/lambda/watchlist-management/index.js
@@ -35,7 +35,7 @@ exports.handler = async (event) => {
     }
 
     // ================== PUT /plates ==================
-    if (httpMethod === "PUT") {
+    if (httpMethod === "POST") {
       // Extract API Key from headers
       const apiKey = headers["x-api-key"];
       if (!apiKey || !API_KEY_MAP[apiKey]) {

--- a/lib/plate-patrol-aws-central-server-stack.ts
+++ b/lib/plate-patrol-aws-central-server-stack.ts
@@ -58,23 +58,7 @@ export class PlatePatrolAwsCentralServerStack extends cdk.Stack {
 
     // ================== Resources ==================
     // ----------------- /detections -------------------
-    // GET /detections - should return a 400 error
     const detectionsResource = api.root.addResource("detections");
-    detectionsResource.addMethod(
-      "GET",
-      new apigateway.MockIntegration({
-        integrationResponses: [
-          {
-            statusCode: "400",
-            responseTemplates: {
-              "application/json": `{"error": "plate_number is required"}`,
-            },
-          },
-        ],
-        requestTemplates: { "application/json": `{}` },
-      }),
-      { methodResponses: [{ statusCode: "400" }] }
-    );
 
     // GET /detections/{plate_number} - should call the Lambda function
     detectionsResource

--- a/lib/plate-patrol-aws-central-server-stack.ts
+++ b/lib/plate-patrol-aws-central-server-stack.ts
@@ -87,8 +87,7 @@ export class PlatePatrolAwsCentralServerStack extends cdk.Stack {
     // GET /plates - Internal use only
     platesResource.addMethod(
       "GET",
-      new apigateway.LambdaIntegration(watchlistManagementLambda),
-      { authorizationType: apigateway.AuthorizationType.IAM } // Restrict to internal use
+      new apigateway.LambdaIntegration(watchlistManagementLambda)
     );
 
     // PUT /plates - Public API to add a plate to the watchlist

--- a/lib/plate-patrol-aws-central-server-stack.ts
+++ b/lib/plate-patrol-aws-central-server-stack.ts
@@ -94,7 +94,7 @@ export class PlatePatrolAwsCentralServerStack extends cdk.Stack {
 
     // PUT /plates - Public API to add a plate to the watchlist
     platesResource.addMethod(
-      "PUT",
+      "POST",
       new apigateway.LambdaIntegration(watchlistManagementLambda),
       {
         apiKeyRequired: true, // Require API Key for PUT

--- a/lib/plate-patrol-aws-central-server-stack.ts
+++ b/lib/plate-patrol-aws-central-server-stack.ts
@@ -84,7 +84,9 @@ export class PlatePatrolAwsCentralServerStack extends cdk.Stack {
     // ================== /plates API ==================
     const platesResource = api.root.addResource("plates");
 
-    // GET /plates - Internal use only
+    // GET /plates - Get the list of plates in the watchlist
+    // Internal use only
+    // TODO: Improve this to require an dev IAM role
     platesResource.addMethod(
       "GET",
       new apigateway.LambdaIntegration(watchlistManagementLambda)
@@ -98,6 +100,14 @@ export class PlatePatrolAwsCentralServerStack extends cdk.Stack {
         apiKeyRequired: true, // Require API Key for PUT
       }
     );
+
+    // DELETE /plates - Internal use only
+    platesResource
+      .addResource("{plate_number}")
+      .addMethod(
+        "DELETE",
+        new apigateway.LambdaIntegration(watchlistManagementLambda)
+      );
 
     // Output base URL of the API Gateway
     new cdk.CfnOutput(this, `ApiUrl-${stage}`, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "aws-cdk-lib": "2.181.1",
         "axios": "^1.8.3",
         "constructs": "^10.0.0",
-        "esbuild": "^0.25.0"
+        "esbuild": "^0.25.0",
+        "uuid": "^11.1.0"
       },
       "bin": {
         "plate-patrol-aws-central-server": "bin/plate-patrol-aws-central-server.js"
@@ -1613,6 +1614,19 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -3620,6 +3634,19 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@smithy/middleware-serde": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
@@ -4919,6 +4946,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bowser": {
@@ -4931,6 +4959,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5213,6 +5242,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -7096,6 +7126,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7553,6 +7584,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8132,16 +8164,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@aws-cdk/aws-apigateway": "^1.38.0",
         "@aws-cdk/aws-dynamodb": "^1.77.0",
         "@aws-cdk/aws-lambda": "^1.19.0",
-        "@aws-sdk/client-dynamodb": "^3.758.0",
         "@aws-sdk/lib-dynamodb": "^3.758.0",
         "@types/aws-lambda": "^8.10.147",
         "aws-cdk-lib": "2.181.1",
@@ -23,11 +22,13 @@
         "plate-patrol-aws-central-server": "bin/plate-patrol-aws-central-server.js"
       },
       "devDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.767.0",
         "@types/aws-sdk": "^0.0.42",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.7.9",
         "@types/supertest": "^6.0.2",
         "aws-cdk": "2.1003.0",
+        "aws-sdk-client-mock": "^4.1.0",
         "dotenv": "^16.4.7",
         "jest": "^29.7.0",
         "supertest": "^7.0.0",
@@ -3417,6 +3418,35 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
@@ -4157,6 +4187,23 @@
         "undici-types": "~6.20.0"
       }
     },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -4729,6 +4776,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
@@ -4860,7 +4919,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bowser": {
@@ -4873,7 +4931,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5156,7 +5213,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -5297,9 +5353,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -6834,6 +6890,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6873,6 +6936,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7025,7 +7096,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7056,6 +7126,30 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -7249,6 +7343,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7449,7 +7553,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7560,6 +7663,35 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -7906,6 +8038,16 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "aws-cdk-lib": "2.181.1",
     "axios": "^1.8.3",
     "constructs": "^10.0.0",
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "uuid": "^11.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "cdk": "cdk"
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.767.0",
     "@types/aws-sdk": "^0.0.42",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.7.9",
     "@types/supertest": "^6.0.2",
     "aws-cdk": "2.1003.0",
+    "aws-sdk-client-mock": "^4.1.0",
     "dotenv": "^16.4.7",
     "jest": "^29.7.0",
     "supertest": "^7.0.0",
@@ -27,7 +29,6 @@
     "@aws-cdk/aws-apigateway": "^1.38.0",
     "@aws-cdk/aws-dynamodb": "^1.77.0",
     "@aws-cdk/aws-lambda": "^1.19.0",
-    "@aws-sdk/client-dynamodb": "^3.758.0",
     "@aws-sdk/lib-dynamodb": "^3.758.0",
     "@types/aws-lambda": "^8.10.147",
     "aws-cdk-lib": "2.181.1",

--- a/resources/lambdas.ts
+++ b/resources/lambdas.ts
@@ -24,7 +24,7 @@ export class Lambdas {
       },
     });
 
-    // Grant Lambda permissions to read from DynamoDB
+    // Grant Lambda permissions to read from watchlist DynamoDB table
     this.detectionsLambda.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ["dynamodb:GetItem"],
@@ -57,7 +57,7 @@ export class Lambdas {
       }
     );
 
-    // Grant Lambda permissions to read, write, update, and delete from DynamoDB
+    // Grant Lambda permissions to read, write, update, and delete from watchlist DynamoDB table
     this.watchlistManagementLambda.addToRolePolicy(
       new iam.PolicyStatement({
         actions: [
@@ -68,6 +68,14 @@ export class Lambdas {
           "dynamodb:Scan",
         ],
         resources: [`arn:aws:dynamodb:*:*:table/${watchlistTable}`],
+      })
+    );
+
+    // Grant Lambda permissions to write to audit log DynamoDB table
+    this.watchlistManagementLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["dynamodb:PutItem"],
+        resources: [`arn:aws:dynamodb:*:*:table/${auditLogTable}`],
       })
     );
   }

--- a/resources/lambdas.ts
+++ b/resources/lambdas.ts
@@ -7,7 +7,12 @@ export class Lambdas {
   public readonly detectionsLambda: lambda.Function;
   public readonly watchlistManagementLambda: lambda.Function;
 
-  constructor(scope: Construct, watchlistTable: string, s3Bucket: string) {
+  constructor(
+    scope: Construct,
+    watchlistTable: string,
+    auditLogTable: string,
+    s3Bucket: string
+  ) {
     // Define /detections Lambda
     this.detectionsLambda = new lambda.Function(scope, "DetectionsLambda", {
       runtime: lambda.Runtime.NODEJS_18_X,
@@ -47,6 +52,7 @@ export class Lambdas {
         ),
         environment: {
           WATCHLIST_TABLE: watchlistTable,
+          AUDIT_LOG_TABLE: auditLogTable,
         },
       }
     );

--- a/resources/tables.ts
+++ b/resources/tables.ts
@@ -3,8 +3,10 @@ import { Construct } from "constructs";
 
 export class Tables {
   public readonly watchlistTable: dynamodb.Table;
+  public readonly auditLogTable: dynamodb.Table;
 
   constructor(scope: Construct, stage: string) {
+    // Watchlist Table - for storing watchlist data
     this.watchlistTable = new dynamodb.Table(scope, `WatchlistTable-${stage}`, {
       tableName: `global_watchlist_${stage}`, // Unique name per stage
       partitionKey: {
@@ -12,6 +14,20 @@ export class Tables {
         type: dynamodb.AttributeType.STRING,
       },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // Auto-scaling
+    });
+
+    // Audit Log Table - for tracking changes to the watchlist
+    this.auditLogTable = new dynamodb.Table(scope, `AuditLogTable-${stage}`, {
+      tableName: `audit_logs_${stage}`,
+      partitionKey: {
+        name: "log_id",
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: "timestamp",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
     });
   }
 }

--- a/tests/jest/detections.test.ts
+++ b/tests/jest/detections.test.ts
@@ -40,28 +40,11 @@ describe("/detections integration tests", () => {
     console.log("Test plate deleted.");
   });
 
-  // ============== Test Unauthorized Requests ==============
-  it("should return 403 for missing API key", async () => {
-    const response = await request(API_URL).get(`/detections/${TEST_PLATE_NUMBER}`);
-
-    expect(response.statusCode).toBe(403);
-    expect(response.body).toEqual({ error: "Unauthorized: Invalid API Key" });
-  });
-
-  it("should return 403 for invalid API key", async () => {
-    const response = await request(API_URL)
-      .get(`/detections/${TEST_PLATE_NUMBER}`)
-      .set("x-api-key", INVALID_API_KEY);
-
-    expect(response.statusCode).toBe(403);
-    expect(response.body).toEqual({ error: "Unauthorized: Invalid API Key" });
-  });
-
   // ============== Test Plate Detection ==============
-  it("should detect a plate in the watchlist", async () => {
-    const response = await request(API_URL)
-      .get(`/detections/${TEST_PLATE_NUMBER}`)
-      .set("x-api-key", VALID_API_KEY);
+  it("should return match: true for a plate in the watchlist", async () => {
+    const response = await request(API_URL).get(
+      `/detections/${TEST_PLATE_NUMBER}`
+    );
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toHaveProperty("match", true);
@@ -70,9 +53,7 @@ describe("/detections integration tests", () => {
   });
 
   it("should return match: false for a plate not in the watchlist", async () => {
-    const response = await request(API_URL)
-      .get(`/detections/NOT_IN_LIST`)
-      .set("x-api-key", VALID_API_KEY);
+    const response = await request(API_URL).get(`/detections/NOT_IN_LIST`);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({ match: false });
@@ -80,9 +61,7 @@ describe("/detections integration tests", () => {
 
   // ============== Test Missing Plate Number ==============
   it("should return 400 when missing plate_number", async () => {
-    const response = await request(API_URL)
-      .get(`/detections/`) // Incorrectly formatted request
-      .set("x-api-key", VALID_API_KEY);
+    const response = await request(API_URL).get(`/detections`); // Incorrectly formatted request
 
     expect(response.statusCode).toBe(400);
     expect(response.body).toEqual({ error: "plate_number is required" });

--- a/tests/jest/detections.test.ts
+++ b/tests/jest/detections.test.ts
@@ -1,96 +1,16 @@
 import request from "supertest";
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import {
-  DynamoDBDocumentClient,
-  PutCommand,
-  DeleteCommand,
-} from "@aws-sdk/lib-dynamodb";
 import dotenv from "dotenv";
 
 // Load environment variables
 dotenv.config();
 
-// Define API Gateway URL
-const API_BASE_URL = process.env.API_URL || "http://localhost:3000";
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:3000";
 const STAGE = process.env.STAGE || "dev";
 const API_URL = `${API_BASE_URL}/${STAGE}`;
+console.log("API_URL: ", API_URL);
 
-const TEST_PLATE = "XYZ123";
-const UNKNOWN_PLATE = "UNKNOWN123";
-
-// Configure AWS DynamoDB
-const ddbClient = new DynamoDBClient({
-  region: process.env.AWS_REGION || "us-east-2",
-});
-const dynamoDB = DynamoDBDocumentClient.from(ddbClient);
-const WATCHLIST_TABLE = process.env.WATCHLIST_TABLE || "global_watchlist_dev";
-
-describe("/detections API Integration Tests", () => {
-  beforeAll(async () => {
-    console.log(`Setting up test plate in DynamoDB: ${TEST_PLATE}`);
-
-    const putParams = {
-      TableName: WATCHLIST_TABLE,
-      Item: {
-        plate_number: TEST_PLATE,
-        tracking_info: {
-          "officer-1": { reason: "stolen" },
-        },
-      },
-    };
-
-    await dynamoDB.send(new PutCommand(putParams));
-  });
-
-  afterAll(async () => {
-    console.log(`Cleaning up test plate from DynamoDB: ${TEST_PLATE}`);
-
-    const deleteParams = {
-      TableName: WATCHLIST_TABLE,
-      Key: { plate_number: TEST_PLATE },
-    };
-
-    await dynamoDB.send(new DeleteCommand(deleteParams));
-  });
-
-  // ============== Test Known Plate Detection ==============
-  it("should detect a plate that exists in the watchlist", async () => {
-    const response = await request(API_URL).get(`/detections/${TEST_PLATE}`);
-
-    expect(response.statusCode).toBe(200);
-    expect(response.body).toHaveProperty("match", true);
-    expect(response.body).toHaveProperty("plate_number", TEST_PLATE);
-    expect(response.body.tracking_info).toHaveProperty("officer-1");
-    expect(response.body.tracking_info["officer-1"].reason).toBe("stolen");
-  });
-
-  // ============== Test Unknown Plate Detection ==============
-  it("should return match=false for a plate not in the watchlist", async () => {
-    const response = await request(API_URL).get(`/detections/${UNKNOWN_PLATE}`);
-
-    expect(response.statusCode).toBe(200);
-    expect(response.body).toHaveProperty("match", false);
-    expect(response.body).toHaveProperty("plate_number", UNKNOWN_PLATE);
-  });
-
-  // ============== Test Missing Plate Number ==============
-  it("should return an error when querying without a plate_number", async () => {
-    const response = await request(API_URL).get(`/detections`);
-
-    expect(response.statusCode).toBe(404); // API Gateway should return 404 if the route is incorrect
-  });
-
-  // ============== Test Pre-signed S3 URL Generation ==============
-  it("should generate a valid pre-signed S3 URL for match upload", async () => {
-    const response = await request(API_URL).get(`/detections/${TEST_PLATE}`);
-
-    expect(response.statusCode).toBe(200);
-
-    if (response.body.match) {
-      expect(response.body).toHaveProperty("upload_url");
-      expect(response.body.upload_url).toContain("https://");
-      expect(response.body.upload_url).toContain(".s3.");
-      expect(response.body.upload_url).toContain("amazonaws.com/");
-    }
-  });
-});
+const VALID_API_KEY = process.env.VALID_API_KEY || "";
+console.log("VALID_API_KEY: ", VALID_API_KEY);
+const INVALID_API_KEY = "invalid-api-key";
+const TEST_PLATE_NUMBER = "ABC123";
+const TEST_REASON = "Suspicious vehicle";

--- a/tests/jest/detections.test.ts
+++ b/tests/jest/detections.test.ts
@@ -14,3 +14,77 @@ console.log("VALID_API_KEY: ", VALID_API_KEY);
 const INVALID_API_KEY = "invalid-api-key";
 const TEST_PLATE_NUMBER = "ABC123";
 const TEST_REASON = "Suspicious vehicle";
+
+describe("/detections integration tests", () => {
+  beforeAll(async () => {
+    // Ensure the test plate is added to the watchlist before running detection tests
+    console.log("Adding test plate to watchlist...");
+    const response = await request(API_URL)
+      .put("/plates")
+      .set("x-api-key", VALID_API_KEY)
+      .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
+
+    expect(response.statusCode).toBe(200);
+    console.log("Test plate added.");
+  });
+
+  afterAll(async () => {
+    // Clean up test plate from the watchlist
+    console.log("Removing test plate from watchlist...");
+    const response = await request(API_URL)
+      .delete(`/plates/${TEST_PLATE_NUMBER}`)
+      .set("x-api-key", VALID_API_KEY);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ message: "Plate removed from watchlist" });
+    console.log("Test plate deleted.");
+  });
+
+  // ============== Test Unauthorized Requests ==============
+  it("should return 403 for missing API key", async () => {
+    const response = await request(API_URL).get(`/detections/${TEST_PLATE_NUMBER}`);
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toEqual({ error: "Unauthorized: Invalid API Key" });
+  });
+
+  it("should return 403 for invalid API key", async () => {
+    const response = await request(API_URL)
+      .get(`/detections/${TEST_PLATE_NUMBER}`)
+      .set("x-api-key", INVALID_API_KEY);
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toEqual({ error: "Unauthorized: Invalid API Key" });
+  });
+
+  // ============== Test Plate Detection ==============
+  it("should detect a plate in the watchlist", async () => {
+    const response = await request(API_URL)
+      .get(`/detections/${TEST_PLATE_NUMBER}`)
+      .set("x-api-key", VALID_API_KEY);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toHaveProperty("match", true);
+    expect(response.body).toHaveProperty("upload_url");
+    expect(response.body).toHaveProperty("file_key");
+  });
+
+  it("should return match: false for a plate not in the watchlist", async () => {
+    const response = await request(API_URL)
+      .get(`/detections/NOT_IN_LIST`)
+      .set("x-api-key", VALID_API_KEY);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ match: false });
+  });
+
+  // ============== Test Missing Plate Number ==============
+  it("should return 400 when missing plate_number", async () => {
+    const response = await request(API_URL)
+      .get(`/detections/`) // Incorrectly formatted request
+      .set("x-api-key", VALID_API_KEY);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual({ error: "plate_number is required" });
+  });
+});

--- a/tests/jest/detections.test.ts
+++ b/tests/jest/detections.test.ts
@@ -20,7 +20,7 @@ describe("/detections integration tests", () => {
     // Ensure the test plate is added to the watchlist before running detection tests
     console.log("Adding test plate to watchlist...");
     const response = await request(API_URL)
-      .put("/plates")
+      .post("/plates")
       .set("x-api-key", VALID_API_KEY)
       .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
 
@@ -60,10 +60,9 @@ describe("/detections integration tests", () => {
   });
 
   // ============== Test Missing Plate Number ==============
-  it("should return 400 when missing plate_number", async () => {
-    const response = await request(API_URL).get(`/detections`); // Incorrectly formatted request
+  it("should return error when missing plate_number", async () => {
+    const response = await request(API_URL).get(`/detections/`);
 
-    expect(response.statusCode).toBe(400);
-    expect(response.body).toEqual({ error: "plate_number is required" });
+    expect(response.statusCode).toBe(403); // 403 Forbidden
   });
 });

--- a/tests/jest/watchlist-management.test.ts
+++ b/tests/jest/watchlist-management.test.ts
@@ -22,7 +22,7 @@ describe("/plates integration tests", () => {
       `/plates/${TEST_PLATE_NUMBER}`
     );
     expect(response.statusCode).toBe(200);
-    expect(response.body).toEqual({ message: "Plate deleted from watchlist" });
+    expect(response.body).toEqual({ message: "Plate removed from watchlist" });
     console.log("Test plate deleted from the watchlist");
   });
 

--- a/tests/jest/watchlist-management.test.ts
+++ b/tests/jest/watchlist-management.test.ts
@@ -1,81 +1,113 @@
-require("dotenv").config();
-const axios = require("axios");
+import request from "supertest";
+import dotenv from "dotenv";
 
-const STAGE = process.env.STAGE;
-const API_URL = `${process.env.API_URL}/${STAGE}/plates`;
+// Load environment variables
+dotenv.config();
 
-const PLATE_NUMBER = "XYZ123";
-const OFFICER_1 = "officer-1";
-const REASON_1 = "stolen";
-const OFFICER_2 = "officer-2";
-const REASON_2 = "suspicious activity";
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:3000";
+const STAGE = process.env.STAGE || "dev";
+const API_URL = `${API_BASE_URL}/${STAGE}`;
+console.log("API_URL: ", API_URL);
 
-// Temporarily skip the tests since we're going to refactor the code
-describe.skip("Watchlist API Tests", () => {
-  beforeAll(async () => {
-    // Cleanup: Remove plate from the watchlist before running tests
-    await axios
-      .delete(`${API_URL}/${PLATE_NUMBER}/officers/${OFFICER_1}`)
-      .catch(() => {});
-    await axios
-      .delete(`${API_URL}/${PLATE_NUMBER}/officers/${OFFICER_2}`)
-      .catch(() => {});
-  });
+const VALID_API_KEY = process.env.VALID_API_KEY || "";
+console.log("VALID_API_KEY: ", VALID_API_KEY);
+const INVALID_API_KEY = "invalid-api-key";
+const TEST_PLATE_NUMBER = "ABC123";
+const TEST_REASON = "Suspicious vehicle";
 
+describe("/plates integration tests", () => {
   afterAll(async () => {
-    // Cleanup: Ensure test data is removed after tests
-    await axios
-      .delete(`${API_URL}/${PLATE_NUMBER}/officers/${OFFICER_1}`)
-      .catch(() => {});
-    await axios
-      .delete(`${API_URL}/${PLATE_NUMBER}/officers/${OFFICER_2}`)
-      .catch(() => {});
+    // Clean up the test plate from the watchlist
+    // Since we don't have a DELETE endpoint, we'll just remove it manually
+  });
+  // ============== Test Unauthorized Requests ==============
+  it("should return 403 for missing API key", async () => {
+    const response = await request(API_URL)
+      .put("/plates")
+      .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toEqual({ message: "Forbidden" });
   });
 
-  test("Should add a plate to the watchlist", async () => {
-    const response = await axios.post(API_URL, {
-      plate_number: PLATE_NUMBER,
-      officer_id: OFFICER_1,
-      reason: REASON_1,
+  it("should return 403 for invalid API key", async () => {
+    const response = await request(API_URL)
+      .put("/plates")
+      .set("x-api-key", INVALID_API_KEY)
+      .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toEqual({ message: "Forbidden" });
+  });
+
+  // ============== Test Adding to Watchlist ==============
+  describe("Add plate to watchlist", () => {
+    it("should successfully add a plate to the watchlist", async () => {
+      const response = await request(API_URL)
+        .put("/plates")
+        .set("x-api-key", VALID_API_KEY)
+        .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toHaveProperty(
+        "message",
+        "Plate added to watchlist"
+      );
     });
 
-    expect(response.status).toBe(200);
-    expect(response.data.message).toMatch(
-      /Plate added to global watchlist|Plate already tracked, officer added/
-    );
-  });
+    // ============== Test Duplicate Plate Addition ==============
+    it("should return an error when adding a duplicate plate", async () => {
+      const response = await request(API_URL)
+        .put("/plates")
+        .set("x-api-key", VALID_API_KEY)
+        .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
 
-  test("Should verify the plate exists in the watchlist", async () => {
-    const response = await axios.get(API_URL);
-    const plates = response.data;
-
-    const plateExists = plates.some(
-      (entry: { plate_number: string }) => entry.plate_number === PLATE_NUMBER
-    );
-    expect(plateExists).toBe(true);
-  });
-
-  test("Should add another officer tracking the same plate", async () => {
-    const response = await axios.post(API_URL, {
-      plate_number: PLATE_NUMBER,
-      officer_id: OFFICER_2,
-      reason: REASON_2,
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toHaveProperty(
+        "message",
+        "Plate already exists, skipping insert."
+      );
     });
-
-    expect(response.status).toBe(200);
-    expect(response.data.message).toBe("Plate already tracked, officer added");
   });
 
-  test("Should confirm both officers are tracking the plate", async () => {
-    const response = await axios.get(`${API_URL}/${PLATE_NUMBER}`);
-    const plateDetails = response.data;
+  // ============== Test Retrieving Watchlist ==============
+  it("should retrieve the list of plates in the watchlist", async () => {
+    const response = await request(API_URL)
+      .get("/plates")
+      .set("x-api-key", VALID_API_KEY);
 
-    expect(plateDetails).toHaveProperty("tracking_officers");
-    const trackedOfficers = plateDetails.tracking_officers.map(
-      (officer: { officer_id: any }) => officer.officer_id
+    expect(response.statusCode).toBe(200);
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ plate_number: TEST_PLATE_NUMBER }),
+      ])
     );
-    expect(trackedOfficers).toEqual(
-      expect.arrayContaining([OFFICER_1, OFFICER_2])
-    );
+  });
+
+  // ============== Test Adding Without Required Fields ==============
+  it("should return 400 when missing plate_number", async () => {
+    const response = await request(API_URL)
+      .put("/plates")
+      .set("x-api-key", VALID_API_KEY)
+      .send({ reason: TEST_REASON });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual({
+      error: "Missing required fields: plate_number, reason",
+    });
+  });
+
+  // ============== Test Adding Without Reason ==============
+  it("should return 400 when missing reason", async () => {
+    const response = await request(API_URL)
+      .put("/plates")
+      .set("x-api-key", VALID_API_KEY)
+      .send({ plate_number: TEST_PLATE_NUMBER });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual({
+      error: "Missing required fields: plate_number, reason",
+    });
   });
 });

--- a/tests/jest/watchlist-management.test.ts
+++ b/tests/jest/watchlist-management.test.ts
@@ -18,8 +18,14 @@ const TEST_REASON = "Suspicious vehicle";
 describe("/plates integration tests", () => {
   afterAll(async () => {
     // Clean up the test plate from the watchlist
-    // Since we don't have a DELETE endpoint, we'll just remove it manually
+    const response = await request(API_URL).delete(
+      `/plates/${TEST_PLATE_NUMBER}`
+    );
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ message: "Plate deleted from watchlist" });
+    console.log("Test plate deleted from the watchlist");
   });
+
   // ============== Test Unauthorized Requests ==============
   it("should return 403 for missing API key", async () => {
     const response = await request(API_URL)

--- a/tests/jest/watchlist-management.test.ts
+++ b/tests/jest/watchlist-management.test.ts
@@ -29,7 +29,7 @@ describe("/plates integration tests", () => {
   // ============== Test Unauthorized Requests ==============
   it("should return 403 for missing API key", async () => {
     const response = await request(API_URL)
-      .put("/plates")
+      .post("/plates")
       .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
 
     expect(response.statusCode).toBe(403);
@@ -38,7 +38,7 @@ describe("/plates integration tests", () => {
 
   it("should return 403 for invalid API key", async () => {
     const response = await request(API_URL)
-      .put("/plates")
+      .post("/plates")
       .set("x-api-key", INVALID_API_KEY)
       .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
 
@@ -50,7 +50,7 @@ describe("/plates integration tests", () => {
   describe("Add plate to watchlist", () => {
     it("should successfully add a plate to the watchlist", async () => {
       const response = await request(API_URL)
-        .put("/plates")
+        .post("/plates")
         .set("x-api-key", VALID_API_KEY)
         .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
 
@@ -64,7 +64,7 @@ describe("/plates integration tests", () => {
     // ============== Test Duplicate Plate Addition ==============
     it("should return an error when adding a duplicate plate", async () => {
       const response = await request(API_URL)
-        .put("/plates")
+        .post("/plates")
         .set("x-api-key", VALID_API_KEY)
         .send({ plate_number: TEST_PLATE_NUMBER, reason: TEST_REASON });
 
@@ -94,7 +94,7 @@ describe("/plates integration tests", () => {
   // ============== Test Adding Without Required Fields ==============
   it("should return 400 when missing plate_number", async () => {
     const response = await request(API_URL)
-      .put("/plates")
+      .post("/plates")
       .set("x-api-key", VALID_API_KEY)
       .send({ reason: TEST_REASON });
 
@@ -107,7 +107,7 @@ describe("/plates integration tests", () => {
   // ============== Test Adding Without Reason ==============
   it("should return 400 when missing reason", async () => {
     const response = await request(API_URL)
-      .put("/plates")
+      .post("/plates")
       .set("x-api-key", VALID_API_KEY)
       .send({ plate_number: TEST_PLATE_NUMBER });
 

--- a/tests/manual/detections.manual.test.sh
+++ b/tests/manual/detections.manual.test.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+#############################################
+# Manual Tests for GET /detections/{plate_number} API
+# ! This script is outdated - please refer to the jest tests in the /test/jest folder
+#############################################
+
 # Set the stage (dev, staging, prod)
 STAGE="dev"
 

--- a/tests/manual/watchlist-management.test.sh
+++ b/tests/manual/watchlist-management.test.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+############################################
+# Manual Tests for Watchlist Management API
+#! Warning: This test is outdated and needs to be updated
+############################################
+
 # Set the stage (dev, staging, prod)
 STAGE="dev"
 


### PR DESCRIPTION
This PR refactors `/detections` and `/watchlist-management` endpoints, since we switched to an API-first approach instead of a full web app. Now, external services can interact via an API key to `POST` to `/plates` for adding plates to the watchlist.

For detections, I simplified the logic: only plate number check, no more officer tracking info.

All changes are covered by automated Jest tests. 

### Updated API Endpoints
| **Method** | **Endpoint** | **Payload** | **Response** | **What It Does** | **Note** |
|------------|------------|------------|------------|----------------|---------|
| **GET** | `/plates` | _None_ | `{ "plates": [...] }` | Get all plates in the watchlist | Internal use only |
| **GET** | `/plates/{plate_number}` | _None_ | `{ "plate_number": "...", "exists": true/false }` | Check if a plate is in the watchlist | Dash cam detection upload |
| **POST** | `/plates` | `{ "plate_number": "ABC123", "reason": "stolen" }` _(API key required)_ | `{ "message": "Plate added to watchlist" }` | Add a plate to the watchlist | Requires API key |
| **DELETE** | `/plates/{plate_number}` | _None_ | `{ "message": "Plate removed from watchlist" }` | Remove a plate from the watchlist | Internal use only |
| **GET** | `/detections/{plate_number}` | _None_ | `{ "match": true, "upload_url": "...", "file_key": "..." }` or `{ "match": false }` | Check if a detected plate is in the watchlist | Uses **DynamoDB & S3** for image uploads |
