### PR TITLE
Add batch watchlist writer script and modify `GET /plates` endpoint

### DIFF
--- a/lambdas/watchlist-management/index.js
+++ b/lambdas/watchlist-management/index.js
@@ -28,9 +28,13 @@ exports.handler = async (event) => {
     if (httpMethod === "GET") {
       const params = { TableName: WATCHLIST_TABLE };
       const { Items } = await dynamoDB.send(new ScanCommand(params));
+
+      // Extract plate numbers from the Items array
+      const plateNumbers = Items.map((item) => item.plate_number);
+
       return {
         statusCode: 200,
-        body: JSON.stringify(Items || []),
+        body: JSON.stringify(plateNumbers || []),
       };
     }
 

--- a/tools/batch_watchlist_writer.py
+++ b/tools/batch_watchlist_writer.py
@@ -1,0 +1,30 @@
+import boto3
+import random
+import string
+
+def generate_license_plate():
+    """Generate a random license plate with 3 uppercase letters and 4 digits."""
+    letters = ''.join(random.choices(string.ascii_uppercase, k=3))
+    numbers = ''.join(random.choices(string.digits, k=4))
+    return f"{letters}{numbers}"
+
+def batch_insert_plates(table_name, number_of_plates=500):
+    # Create a DynamoDB resource
+    dynamodb = boto3.resource('dynamodb')
+    table = dynamodb.Table(table_name)
+
+    # Generate unique license plates
+    plates = set()
+    while len(plates) < number_of_plates:
+        plates.add(generate_license_plate())
+
+    # Batch write items to DynamoDB
+    with table.batch_writer() as batch:
+        for plate in plates:
+            batch.put_item(Item={'plate_number': plate})
+
+    print(f"Successfully inserted {number_of_plates} license plates into {table_name}.")
+
+if __name__ == "__main__":
+    table_name = 'global_watchlist_dev'
+    batch_insert_plates(table_name)


### PR DESCRIPTION
- Added a script for automatically inserting 500 random license plates into the DynamoDB watchlist table.
- Modified the `GET /plates` endpoint to return only the list of plate numbers instead of the entire item data.
- Tested the changes using manual `curl`.